### PR TITLE
Enable link-local IPv6 for all containers

### DIFF
--- a/pkg/ipam/ipam_linux.go
+++ b/pkg/ipam/ipam_linux.go
@@ -58,9 +58,10 @@ func ConfigureIface(ifName string, res *current.Result) error {
 			return fmt.Errorf("failed to add IP addr %v to %q: invalid interface index", ipc, ifName)
 		}
 
-		// Make sure sysctl "disable_ipv6" is 0 if we are about to add
-		// an IPv6 address to the interface
-		if !has_enabled_ipv6 && ipc.Version == "6" {
+		// Make sure sysctl "disable_ipv6" is 0 so we can get a
+                // link-local IPv6 address even if an IPv6 address
+                // range has not been explicitly chosen.
+		if !has_enabled_ipv6 {
 			// Enabled IPv6 for loopback "lo" and the interface
 			// being configured
 			for _, iface := range [2]string{"lo", ifName} {

--- a/pkg/ipam/ipam_linux.go
+++ b/pkg/ipam/ipam_linux.go
@@ -58,7 +58,7 @@ func ConfigureIface(ifName string, res *current.Result) error {
 			return fmt.Errorf("failed to add IP addr %v to %q: invalid interface index", ipc, ifName)
 		}
 
-		// Make sure sysctl "disable_ipv6" is 0 so we can get a
+                // Make sure sysctl "disable_ipv6" is 0 so we can get a
                 // link-local IPv6 address even if an IPv6 address
                 // range has not been explicitly chosen.
 		if !has_enabled_ipv6 {

--- a/pkg/ipam/ipam_linux.go
+++ b/pkg/ipam/ipam_linux.go
@@ -57,10 +57,10 @@ func ConfigureIface(ifName string, res *current.Result) error {
 			// IP address is for a different interface
 			return fmt.Errorf("failed to add IP addr %v to %q: invalid interface index", ipc, ifName)
 		}
-
-                // Make sure sysctl "disable_ipv6" is 0 so we can get a
-                // link-local IPv6 address even if an IPv6 address
-                // range has not been explicitly chosen.
+		
+		// Make sure sysctl "disable_ipv6" is 0 so we can get a
+		// link-local IPv6 address even if an IPv6 address
+		// range has not been explicitly chosen.
 		if !has_enabled_ipv6 {
 			// Enabled IPv6 for loopback "lo" and the interface
 			// being configured


### PR DESCRIPTION
Currently Docker containers turn off IPv6 by default even though we are running Docker with the `--ipv6` flag. https://github.com/containernetworking/cni/issues/531 fixes this issue by overriding the files to disable IPv6 but only does so if an IPv6 interface has been specified.

Test Plan:

Created a Docker container on Kubernetes and was able to ping6 to a machine on the same network.